### PR TITLE
feat: 프로필 사진 업로드 및 조회 기능 추가

### DIFF
--- a/src/main/java/com/example/decoratemycakebackend/domain/cake/controller/CakeController.java
+++ b/src/main/java/com/example/decoratemycakebackend/domain/cake/controller/CakeController.java
@@ -5,7 +5,6 @@ import com.example.decoratemycakebackend.domain.cake.dto.CakeDeleteRequestDto;
 import com.example.decoratemycakebackend.domain.cake.dto.CakePutRequestDto;
 import com.example.decoratemycakebackend.domain.cake.service.CakeService;
 import com.example.decoratemycakebackend.domain.cake.service.FriendCakeService;
-import com.example.decoratemycakebackend.global.s3.S3Service;
 import com.example.decoratemycakebackend.global.util.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,7 +23,6 @@ public class CakeController {
 
     private final CakeService cakeService;
     private final FriendCakeService friendCakeService;
-    private final S3Service s3Service;
 
 
     @Operation(summary = "나의 역대 케이크 전체 조회", description = "각 연도별 케이크 목록 조회")

--- a/src/main/java/com/example/decoratemycakebackend/domain/member/controler/MemberController.java
+++ b/src/main/java/com/example/decoratemycakebackend/domain/member/controler/MemberController.java
@@ -7,6 +7,7 @@ import com.example.decoratemycakebackend.domain.member.dto.SignUpDto;
 import com.example.decoratemycakebackend.domain.member.service.MemberService;
 import com.example.decoratemycakebackend.global.auth.JwtToken;
 import com.example.decoratemycakebackend.global.auth.JwtTokenProvider;
+import com.example.decoratemycakebackend.global.s3.S3Service;
 import com.example.decoratemycakebackend.global.util.ResponseDto;
 import com.example.decoratemycakebackend.global.util.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,11 +17,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 
 @Tag(name = "회원 관리 API", description = "회원 관련 API endpoints")
 @Slf4j
@@ -30,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
     private final MemberService memberService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final S3Service s3Service;
 
     @Operation(summary = "로그인", description = "이메일과 비밀번호를 사용하여 로그인합니다.")
     @ApiResponses(value = {
@@ -86,6 +89,20 @@ public class MemberController {
     public ResponseEntity<?> logout() {
         String email = SecurityUtil.getCurrentUserEmail();
         memberService.logout(email);
-        return ResponseEntity.ok(new ResponseDto<>("로그아웃 되었습니다ㅏ.", null));
+        return ResponseEntity.ok(new ResponseDto<>("로그아웃 되었습니다.", null));
+    }
+
+    @Operation(summary = "프로필 사진 업로드", description = "png 또는 jpg, jpeg 파일 형식 업로드만 가능. 리사이징 된 이미지를 반환함.")
+    @PostMapping(value = "/upload/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ResponseDto<?>> uploadProfileImage(@RequestParam("file")MultipartFile file) throws IOException {
+        String imageUrl = memberService.uploadProfileImg(file);
+        return ResponseEntity.ok(new ResponseDto<>("프로필 이미지 업로드가 완료되었습니다.", imageUrl));
+    }
+
+    @Operation(summary = "프로필 사진 URL 조회", description = "현재 로그인한 사용자의 프로필 사진 URL을 반환합니다.")
+    @GetMapping("/profile")
+    public ResponseEntity<ResponseDto<?>> getProfileImageUrl() {
+        String imageUrl = memberService.getProfileImgUrl();
+        return ResponseEntity.ok(new ResponseDto<>("프로필 이미지 URL 조회가 완료되었습니다.", imageUrl));
     }
 }

--- a/src/main/java/com/example/decoratemycakebackend/domain/member/entity/Member.java
+++ b/src/main/java/com/example/decoratemycakebackend/domain/member/entity/Member.java
@@ -85,4 +85,8 @@ public class Member implements UserDetails {
         return true;
     }
 
+    public void changeProfileImg(String profileImg) {
+        this.profileImg = profileImg;
+    }
+
 }

--- a/src/main/java/com/example/decoratemycakebackend/global/error/ErrorCode.java
+++ b/src/main/java/com/example/decoratemycakebackend/global/error/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다."),
     EMPTY_FILE_EXCEPTION(HttpStatus.NOT_FOUND, "선택된 파일이 없습니다."),
     FILE_UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "파일 업로드에 실패했습니다."),
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "잘못된 파일 형식입니다."),
     FRIEND_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "친구 요청을 찾을 수 없습니다.");
 
 

--- a/src/main/java/com/example/decoratemycakebackend/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/decoratemycakebackend/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.example.decoratemycakebackend.global.error;
 
+import io.jsonwebtoken.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -92,6 +93,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(ErrorCode.INVALID_REQUEST_BODY.getStatus())
                 .body(new ErrorResponse(ErrorCode.INVALID_REQUEST_BODY));
+    }
+
+    @ExceptionHandler(IOException.class)
+    protected ResponseEntity<ErrorResponse> handlerIOException(IOException e) {
+        log.error("handlerIOException: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 
     /*

--- a/src/main/java/com/example/decoratemycakebackend/global/s3/S3Service.java
+++ b/src/main/java/com/example/decoratemycakebackend/global/s3/S3Service.java
@@ -2,13 +2,23 @@ package com.example.decoratemycakebackend.global.s3;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.example.decoratemycakebackend.global.error.CustomException;
+import com.example.decoratemycakebackend.global.error.ErrorCode;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.image.AffineTransformOp;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.UUID;
 
 @Service
@@ -23,36 +33,63 @@ public class S3Service {
     private String defaultUrl;
 
     private final String dir = "/mycake";
+    private final String profileDir = "/mycake/profile";
 
     @PostConstruct
     public void init() {
         this.defaultUrl = String.format("https://%s.s3.ap-northeast-2.amazonaws.com", bucketName);
     }
 
-    public String uploadFile(MultipartFile file) throws IOException {
+    public String uploadProfileImg(MultipartFile file) throws IOException {
+        String contentType = file.getContentType();
+        if (!contentType.equals("image/jpeg") && !contentType.equals("image/png")) {
+            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
+        }
 
-        String bucketDir = bucketName + dir;
-        String dirUrl = defaultUrl + dir + "/";
+        // 이미지 리사이즈
+        BufferedImage originalImage = ImageIO.read(file.getInputStream());
+        BufferedImage resizedImage = resizeImage(originalImage, 300, 300, contentType);
+
+        // 이미지를 바이트 배열로 변환
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ImageIO.write(resizedImage, contentType.equals("image/png") ? "png" : "jpg", outputStream);
+        byte[] imageBytes = outputStream.toByteArray();
+        InputStream inputStream = new ByteArrayInputStream(imageBytes);
+
+        // S3 업로드
+        String bucketDir = bucketName + profileDir;
+        String dirUrl = defaultUrl + profileDir + "/";
         String fileName = generateFileName(file);
 
-        amazonS3.putObject(bucketDir, fileName, file.getInputStream(), getObjectMetadata(file));
+        amazonS3.putObject(bucketDir, fileName, inputStream, getObjectMetadata(imageBytes.length, contentType));
         return dirUrl + fileName;
+    }
 
+    private BufferedImage resizeImage(BufferedImage originalImage, int targetWidth, int targetHeight, String contentType) {
+        int type = contentType.equals("image/png") ? BufferedImage.TYPE_INT_ARGB : BufferedImage.TYPE_INT_RGB;
+        BufferedImage resizedImage = new BufferedImage(targetWidth, targetHeight, type);
+        Graphics2D g = resizedImage.createGraphics();
+        AffineTransform at = AffineTransform.getScaleInstance(
+                (double) targetWidth / originalImage.getWidth(),
+                (double) targetHeight / originalImage.getHeight());
+        AffineTransformOp scaleOp = new AffineTransformOp(at, AffineTransformOp.TYPE_BILINEAR);
+        g.drawImage(originalImage, scaleOp, 0, 0);
+        g.dispose();
+        return resizedImage;
     }
 
     public String getImageUrl(String url) {
         return defaultUrl + dir + "/" + url + ".png";
     }
 
-    private ObjectMetadata getObjectMetadata(MultipartFile file) {
+    private ObjectMetadata getObjectMetadata(long contentLength, String contentType) {
         ObjectMetadata objectMetadata = new ObjectMetadata();
-        objectMetadata.setContentType(file.getContentType());
-        objectMetadata.setContentLength(file.getSize());
+        objectMetadata.setContentType(contentType);
+        objectMetadata.setContentLength(contentLength);
         return objectMetadata;
     }
 
     private String generateFileName(MultipartFile file) {
         return UUID.randomUUID().toString() + "-" + file.getOriginalFilename();
     }
-
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #53 

## 📝작업 내용

> 
S3에 연동하여 프로필 사진 업로드 -> 리사이징, 파일 형식 유지, jpeg와 png만 허용하도록 구현
로그인 한 멤버의 프로필 사진 조회기능 구현